### PR TITLE
feat: add config name support

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -42,6 +42,25 @@ You can also select specific list of models to run the health check on by provid
 
     datapilot dbt project-health --manifest-path ./target/manifest.json --select "path:dir1 path:dir2 model1 model2"
 
-This will run the health check on all the models in the 'dir1' and 'dir2' directory. It will also run the health check on the 'model1' and 'model2' models.
+This will run the health check on all the models in the 'dir1' and 'dir2' directory, as well as the 'model1' and 'model2' models.
 As of now, the '--select' flag only supports filtering based on model path and model name. We will add support for other filters and make it compatible
-with the dbt comands soon.
+with the dbt commands soon.
+
+3. **Configuration**:
+You can provide configuration in two ways:
+
+a. Using a local config file:
+    .. code-block:: shell
+
+        datapilot dbt project-health --manifest-path ./target/manifest.json --config-path ./path/to/config.yml
+
+b. Using a named config from the API:
+    .. code-block:: shell
+
+        datapilot dbt project-health --manifest-path ./target/manifest.json --config-name "my-config" --token "YOUR_API_TOKEN" --instance-name "YOUR_INSTANCE"
+
+The ``--config-name`` option allows you to use a configuration stored in the Altimate API. When using this option, you must also provide:
+- ``--token``: Your API token for authentication
+- ``--instance-name``: Your tenant ID
+
+If both ``--config-path`` and ``--config-name`` are provided, the local config file (``--config-path``) takes precedence.

--- a/src/datapilot/clients/altimate/client.py
+++ b/src/datapilot/clients/altimate/client.py
@@ -104,3 +104,9 @@ class APIClient:
             "check_names": check_names,
         }
         return self.post(endpoint, data=data)
+
+    def get_all_dbt_configs(self):
+        """Get all DBT configs with a page size of 100."""
+        endpoint = "/dbt/v1/configs"
+        params = {"size": 100}
+        return self.get(endpoint, params=params)

--- a/src/datapilot/clients/altimate/client.py
+++ b/src/datapilot/clients/altimate/client.py
@@ -107,6 +107,6 @@ class APIClient:
 
     def get_all_dbt_configs(self):
         """Get all DBT configs with a page size of 100."""
-        endpoint = "/dbt/v1/configs"
+        endpoint = "/dbtconfig/"
         params = {"size": 100}
         return self.get(endpoint, params=params)

--- a/src/datapilot/clients/altimate/utils.py
+++ b/src/datapilot/clients/altimate/utils.py
@@ -124,3 +124,13 @@ def run_project_governance_llm_checks(
 ):
     api_client = APIClient(api_token=api_token, base_url=backend_url, tenant=tenant)
     return api_client.run_project_governance_llm_checks(manifest, catalog, check_names)
+
+
+def get_all_dbt_configs(
+    api_token,
+    tenant,
+    backend_url,
+):
+    """Get all DBT configs from the API."""
+    api_client = APIClient(api_token=api_token, base_url=backend_url, tenant=tenant)
+    return api_client.get_all_dbt_configs()

--- a/src/datapilot/core/platforms/dbt/cli/cli.py
+++ b/src/datapilot/core/platforms/dbt/cli/cli.py
@@ -83,6 +83,7 @@ def project_health(
             matching_configs = [c for c in configs["items"] if c["name"] == config_name]
             if matching_configs:
                 # Get the config directly from the API response
+                click.echo(f"Using config: {config_name}")
                 config = matching_configs[0].get("config", {})
             else:
                 click.echo(f"No config found with name: {config_name}")

--- a/src/datapilot/core/platforms/dbt/cli/cli.py
+++ b/src/datapilot/core/platforms/dbt/cli/cli.py
@@ -3,6 +3,7 @@ import logging
 import click
 
 from datapilot.clients.altimate.utils import check_token_and_instance
+from datapilot.clients.altimate.utils import get_all_dbt_configs
 from datapilot.clients.altimate.utils import onboard_file
 from datapilot.clients.altimate.utils import start_dbt_ingestion
 from datapilot.clients.altimate.utils import validate_credentials
@@ -46,6 +47,11 @@ def dbt():
     help="Path to the DBT config file",
 )
 @click.option(
+    "--config-name",
+    required=False,
+    help="Name of the DBT config to use from the API",
+)
+@click.option(
     "--select",
     required=False,
     default=None,
@@ -53,7 +59,14 @@ def dbt():
 )
 @click.option("--backend-url", required=False, help="Altimate's Backend URL", default="https://api.myaltimate.com")
 def project_health(
-    token, instance_name, manifest_path, catalog_path, config_path=None, select=None, backend_url="https://api.myaltimate.com"
+    token,
+    instance_name,
+    manifest_path,
+    catalog_path,
+    config_path=None,
+    config_name=None,
+    select=None,
+    backend_url="https://api.myaltimate.com",
 ):
     """
     Validate the DBT project's configuration and structure.
@@ -62,6 +75,22 @@ def project_health(
     config = None
     if config_path:
         config = load_config(config_path)
+    elif config_name and token and instance_name:
+        # Get configs from API
+        configs = get_all_dbt_configs(token, instance_name, backend_url)
+        if configs and "items" in configs:
+            # Find config by name
+            matching_configs = [c for c in configs["items"] if c["name"] == config_name]
+            if matching_configs:
+                # Get the config directly from the API response
+                config = matching_configs[0].get("config", {})
+            else:
+                click.echo(f"No config found with name: {config_name}")
+                return
+        else:
+            click.echo("Failed to fetch configs from API")
+            return
+
     selected_models = []
     if select:
         selected_models = select.split(" ")

--- a/src/datapilot/core/platforms/dbt/wrappers/manifest/v10/wrapper.py
+++ b/src/datapilot/core/platforms/dbt/wrappers/manifest/v10/wrapper.py
@@ -116,7 +116,7 @@ class ManifestV10Wrapper(BaseManifestWrapper):
             contract=contract,
             meta=node.meta,
             patch_path=node.patch_path,
-            access=node.access.value,
+            access=getattr(node.access, "value", None) if hasattr(node, "access") and node.access is not None else None,
         )
 
     def _get_source(self, source: SourceNode) -> AltimateManifestSourceNode:

--- a/src/datapilot/core/platforms/dbt/wrappers/manifest/v11/wrapper.py
+++ b/src/datapilot/core/platforms/dbt/wrappers/manifest/v11/wrapper.py
@@ -116,7 +116,7 @@ class ManifestV11Wrapper(BaseManifestWrapper):
             contract=contract,
             meta=node.meta,
             patch_path=node.patch_path,
-            access=node.access.value,
+            access=getattr(node.access, "value", None) if hasattr(node, "access") and node.access is not None else None,
         )
 
     def _get_source(self, source: SourceNode) -> AltimateManifestSourceNode:

--- a/src/datapilot/core/platforms/dbt/wrappers/manifest/v12/wrapper.py
+++ b/src/datapilot/core/platforms/dbt/wrappers/manifest/v12/wrapper.py
@@ -116,7 +116,7 @@ class ManifestV12Wrapper(BaseManifestWrapper):
             contract=contract,
             meta=node.meta,
             patch_path=node.patch_path,
-            access=node.access.value,
+            access=getattr(node.access, "value", None) if hasattr(node, "access") and node.access is not None else None,
         )
 
     def _get_source(self, source: SourceNode) -> AltimateManifestSourceNode:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add support for named configuration in `project-health` command, allowing use of configurations from the Altimate API with precedence rules and updated documentation.
> 
>   - **Behavior**:
>     - Add `--config-name` option to `project-health` command in `cli.py` to use named configurations from the Altimate API.
>     - If both `--config-path` and `--config-name` are provided, `--config-path` takes precedence.
>     - Handle missing `access` attribute in `_get_node()` in `wrapper.py` for v10, v11, and v12.
>   - **API Client**:
>     - Add `get_all_dbt_configs()` to `client.py` to fetch DBT configurations from the API.
>     - Add `get_all_dbt_configs()` utility function in `utils.py`.
>   - **Documentation**:
>     - Update `features.rst` to include instructions for using `--config-name` and related options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AltimateAI%2Fdatapilot-cli&utm_source=github&utm_medium=referral)<sup> for b691261a2bd539f7fe75bc8b5e49ac5d512e5284. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->