### PR TITLE
feat: update dbt-artifacts-parser dependency to 0.9.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(*names, **kwargs):
 
 setup(
     name="altimate-datapilot-cli",
-    version="0.0.21",
+    version="0.0.22",
     license="MIT",
     description="Assistant for Data Teams",
     long_description="{}\n{}".format(
@@ -63,7 +63,7 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         "click~=8.1.7",
-        "dbt-artifacts-parser~=0.8.1",
+        "dbt-artifacts-parser~=0.9.0",
         "ruamel.yaml~=0.18.6",
         "tabulate~=0.9.0",
         "requests>=2.31",

--- a/src/datapilot/core/platforms/dbt/schemas/manifest.py
+++ b/src/datapilot/core/platforms/dbt/schemas/manifest.py
@@ -18,6 +18,7 @@ from dbt_artifacts_parser.parsers.manifest.manifest_v9 import ManifestV9
 from dbt_artifacts_parser.parsers.manifest.manifest_v10 import ManifestV10
 from dbt_artifacts_parser.parsers.manifest.manifest_v11 import ManifestV11
 from dbt_artifacts_parser.parsers.manifest.manifest_v11 import SupportedLanguage
+from dbt_artifacts_parser.parsers.manifest.manifest_v12 import ManifestV12
 from pydantic import BaseModel
 
 
@@ -28,6 +29,7 @@ class DBTVersion(BaseModel):
 
 
 Manifest = Union[
+    ManifestV12,
     ManifestV11,
     ManifestV10,
     ManifestV9,


### PR DESCRIPTION
Add support for ManifestV12 in DBTVersion union.
<img width="922" height="461" alt="Screenshot 2025-07-31 at 7 09 29 PM" src="https://github.com/user-attachments/assets/6ac6f905-e0d6-43d2-8ad0-f1ddd7d9de33" />


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `dbt-artifacts-parser` to 0.9.0 and add `ManifestV12` support in `manifest.py`.
> 
>   - **Dependencies**:
>     - Update `dbt-artifacts-parser` to version `0.9.0` in `setup.py`.
>   - **Versioning**:
>     - Bump version from `0.0.21` to `0.0.22` in `setup.py`.
>   - **Schema Support**:
>     - Add `ManifestV12` to `Manifest` union in `manifest.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AltimateAI%2Fdatapilot-cli&utm_source=github&utm_medium=referral)<sup> for 5637072edda939203905fab2ab75b9afa3a40d25. You can [customize](https://app.ellipsis.dev/AltimateAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->