### PR TITLE
fix: use forked dbt-artifacts-parser

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     python_requires=">=3.8",
     install_requires=[
         "click~=8.1.7",
-        "dbt-artifacts-parser~=0.9.0",
+        "dbt-artifacts-parser @ git+https://github.com/mdesmet/dbt-artifacts-parser.git@2c0810ee557feeeaca66a8c46a0b764bb8f3a0bc",
         "ruamel.yaml~=0.18.6",
         "tabulate~=0.9.0",
         "requests>=2.31",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `dbt-artifacts-parser` dependency in `setup.py` to use a forked version from a specific branch.
> 
>   - **Dependencies**:
>     - Update `dbt-artifacts-parser` dependency in `setup.py` to use a forked version from `mdesmet/dbt-artifacts-parser.git@fix/dbt-cloud-manifest`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=AltimateAI%2Fdatapilot-cli&utm_source=github&utm_medium=referral)<sup> for 255333a66ca9c50d672813f9e4ee638a41deb74e. You can [customize](https://app.ellipsis.dev/AltimateAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->