### PR TITLE
chore: bump `sqlglot` pin to `sqlglot[c]==30.7.0`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
         "ruamel.yaml~=0.18.6",
         "tabulate~=0.9.0",
         "requests>=2.31",
-        "sqlglot~=25.30.0",
+        "sqlglot[c]==30.7.0",
         "mcp~=1.9.0",
         "pyperclip~=1.8.2",
         "python-dotenv~=1.0.0",


### PR DESCRIPTION
## Summary

Bump the `sqlglot` install requirement from `sqlglot~=25.30.0` to
`sqlglot[c]==30.7.0` to align with the pin being adopted in
[AltimateAI/altimate-dags#1024](https://github.com/AltimateAI/altimate-dags/pull/1024) (sqlglot[c] v30 — 6.8x parsing speedup).

`SqlCheck` (`src/datapilot/core/platforms/dbt/insights/sql/sql_check.py`)
is the only place in datapilot-cli that imports `sqlglot`. It uses the
optimizer rules (`pushdown_projections`, `normalize`, `unnest_subqueries`,
`eliminate_subqueries`, `eliminate_joins`, `eliminate_ctes`) and inspects
each rule's signature via `inspect.getfullargspec(rule).args`. Verified
that sqlglot[c] 30.7.0 still exposes proper signatures via mypyc — no
compat shim is needed.

## Non-breaking validation

| Check | sqlglot 25.30.0 (old pin) | sqlglot[c] 30.7.0 (new pin) |
|---|---|---|
| `pytest tests/` | **77 passed** | **77 passed** |
| `inspect.getfullargspec` on optimizer rules | OK | OK |
| Pipeline rule execution (parse → qualify → 6 optimizer rules) | 0 errors | 0 errors |
| SqlCheck insights on a 7-query fixture | 6 insights | **6 insights, byte-identical recommendations** |

The 7-query fixture covered filter pushdown, CTE chains, unused joins,
IN-subqueries, `SELECT DISTINCT` dedup, complex OR/AND filters, and a
no-optimization-needed baseline. Output recommendations are character-
identical between versions.

## Why exact pin (`==30.7.0`) and not a range

Matches the version validated in altimate-dags#1024 against 1,986,940
production queries (and re-validated today on 214,259 rakuten queries:
99.9991 % byte-identical SQL fingerprints, 0 false negatives, 0 false
positives). Holding the pin tight ensures DAG workers and the
datapilot-cli installed alongside them resolve to the same sqlglot
release; we can relax to a range later if/when 30.x minor bumps are
similarly validated.

Refs: AltimateAI/altimate-dags#1024

## Test plan
- [ ] CI green
- [ ] After merge, cut a new datapilot-cli release and bump the version
      pinned in altimate-infra airflow `extraPipPackages`
      (`apps/{prod,staging/airflow-mi,freemium}/airflow/values.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)