### PR TITLE
docs: add REVIEW.md for KiloCode automated review guidance

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,150 @@
+# REVIEW.md — datapilot-cli
+
+Python CLI (`altimate-datapilot-cli` on PyPI) that parses dbt `manifest.json`/`catalog.json`
+artifacts across dbt manifest schema versions (vendored `dbt-artifacts-parser`, v1–v12) and runs
+data-quality "insight" checks over dbt projects, usable standalone or as a pre-commit hook.
+
+## Goal: catch what CI cannot
+
+CI runs formatting/linting/tests. You exist for correctness bugs in dbt-manifest parsing across
+schema versions, node-shape assumptions, and API/CLI behavior that no linter can see. If a diff is
+clean and doesn't touch any of the areas below, say `lgtm` — don't invent nits.
+
+## Don't duplicate CI — never flag
+
+This repo's `pre-commit` + `tox` pipeline (ruff, black) already enforces, so never re-flag:
+- Formatting (black) or import ordering (`ruff` rule `I`/isort).
+- Unused imports/variables, bare `except`, raise-from style (`RUF`, `RSE`), bugbear patterns (`B`),
+  comprehension style (`C4`), pathlib usage (`PTH`), quote style (`Q`), pytest style (`PT`).
+- Naive `datetime` construction — ruff's `DTZ` rule already catches this.
+- Basic `flake8-bandit` (`S`) security smells (e.g. `assert` in non-test code, `eval`/`exec`).
+- Line length (140 cols, ruff-enforced).
+- Whether tests exist/pass — `tox` runs the suite; that's CI's job, not yours.
+Pre-existing issues in code the diff doesn't touch are out of scope — only review changed lines
+and their direct call sites.
+
+## Evidence standard — no speculation
+
+Before flagging a manifest/catalog-parsing issue, trace which manifest version(s) the changed code
+actually runs against and check the vendored schema in
+`src/vendor/dbt_artifacts_parser/parsers/manifest/manifest_vN.py` for that version — don't assume
+a field exists just because it's on `ManifestV12`. For CLI/API-client changes, trace whether the
+call site actually surfaces failures to the user before claiming error handling is missing.
+
+## Severity calibration
+
+- **Critical**: will raise/crash on a real dbt manifest version this tool claims to support (e.g.
+  missing field, wrong required-ness, wrong checksum shape), or silently drops/misreports an
+  insight-check result.
+- **Warning**: works today but is version-fragile, dialect-fragile, or duplicates logic that will
+  drift (see focus areas below); or an API failure that's swallowed instead of surfaced to the CLI
+  user.
+- **Nit**: naming, magic strings that have an existing constant, minor duplication.
+
+## Focus areas — bug classes this repo actually ships
+
+1. **Pydantic `extra="forbid"` on manifest/catalog wrapper models** (root cause of #92, #48, and
+   related fixes). New dbt manifest versions add fields the `Altimate*` wrapper models don't know
+   about yet; a wrapper `BaseModel` with `extra="forbid"` raises `ValidationError` and crashes
+   parsing the moment dbt ships a minor version bump. Flag any new/edited model in
+   `schemas/manifest.py`-style files whose `model_config` sets `extra="forbid"` (or omits it while
+   inheriting a forbidding base) instead of `extra="allow"`.
+
+2. **Fields marked required on node wrapper models** (#98, #95, #96 — `identifier`,
+   `resource_type` made optional after crashing on `Disabled*`/unit-test nodes). A field required
+   on the "normal" node case often isn't populated on disabled nodes, unit-test nodes, or older
+   manifest versions. Flag any new required (non-`Optional`) field added to an `Altimate*` node
+   model; verify it's actually present across disabled/unit-test/seed/source variants, not just
+   the common model case.
+
+3. **Version-specific field access without a version guard** (e.g. `deferred` not present on v12
+   `RPCNode`; behavior tied to a specific dbt/artifact-parser version). Flag direct attribute
+   access on a vendored `manifest_vN` type inside code paths meant to be version-agnostic; verify
+   against the specific `manifest_vN.py` the code targets.
+
+4. **Checksum/hash shape assumptions** (#94 — `checksum` is a dict on some node types, a
+   string/object on others). Flag `.checksum.name` / `.checksum.checksum`-style access without
+   confirming that node type has that structure in that manifest version.
+
+5. **Catalog/manifest lookups assumed non-`None`** ("catalog nodes can be `None`", catalog can
+   have fewer columns than the manifest). `--catalog-path` is optional per the CLI, and
+   `dbt docs generate` output can be stale relative to the manifest. Flag catalog/manifest
+   `.nodes[x]` / `.columns[y]` access without a `None`/`KeyError` guard in insight-check code.
+
+6. **Mutable default arguments** (explicitly flagged in review — "list is mutable, weird things can
+   happen" — not reliably caught by this repo's ruff config). Flag `def f(x=[])`, `def f(x={})`, or
+   a list/dict class attribute mutated in place across calls instead of copied per-instance.
+
+7. **Hardcoded materialization/dialect assumptions in insight checks** ("dialects may have
+   multiple materializations and it might flag something we don't want to flag", "use the VIEW
+   constant, we have it somewhere"). Flag magic materialization strings (`"view"`, `"table"`,
+   `"incremental"`) instead of the shared constant, and any check that assumes one dialect's
+   materialization vocabulary applies to all configured warehouses.
+
+8. **Duplicated logic across check/insight classes** ("put this in the base `DBTCheck` class so
+   it's not repeated", "make it a reusable util"). Flag near-identical blocks copy-pasted across
+   files under the insights/checks package instead of factored onto a shared base class or util.
+
+9. **API-client failures not surfaced to the CLI user** ("should handle exceptions and not-200s
+   nicely", "get the response code and log it", "return the status so we inform the user what
+   happened"). The API client intentionally doesn't raise on non-2xx (see Known-intentional) — the
+   bug class is the CLI layer silently swallowing that failure instead of reporting it to the
+   user. Flag call sites that ignore or only debug-log a non-2xx/error API response.
+
+10. **Hardcoded environment-specific defaults** ("needs to be injectable from the CLI/environment,
+    not hardcoded"). Flag new hardcoded endpoint/host/instance defaults added to config or client
+    code that aren't also exposed as a CLI flag or env var override.
+
+11. **Enum/resource-type completeness across manifest versions** ("how is it mapping between the
+    enums", "not sure all types have labels"). `AltimateResourceType`/`AltimateAccess`-style enums
+    must track new dbt node/resource types introduced by an artifact-parser version bump. Flag a
+    vendored-parser bump or new node type handled without a corresponding Altimate enum member.
+
+12. **Release/version-bump workflow trigger conditions** (`.bumpversion.cfg`, `bump-version.yml`,
+    `tag-release.yml` — "won't this always release a tag? should be manual"). Flag changes to
+    release-workflow `on:` triggers; verify a routine merge to main can't unintentionally fire a
+    tag/release.
+
+## Repo invariants & landmines
+
+- `Manifest = Union[ManifestV1, ..., ManifestV12]` (`schemas/manifest.py`) — code that pattern-
+  matches or accesses fields without checking manifest version breaks on the boundary versions.
+- `src/vendor/dbt_artifacts_parser` is a deliberately vendored/forked copy (see fix history: "use
+  vendored dbt-artifacts-parser", "use forked dbt-artifacts-parser") — it exists because upstream
+  didn't support something needed here; don't "clean up" divergence from upstream as if it were
+  drift.
+- Two distinct run modes with different data completeness: a full CLI run (`datapilot dbt
+  project-health`) vs. the pre-commit hook, which partially generates manifest/catalog from only
+  changed files. Manifest-loading changes need to work under both.
+- Minimum supported Python is 3.7 per README — avoid relying on syntax/stdlib features unavailable
+  there unless the actual tox/CI matrix has been checked.
+- `--catalog-path` is optional; code paths must degrade gracefully (skip catalog-dependent
+  insights) rather than assume catalog data is present.
+
+## Known-intentional — don't flag
+
+- `APIClient.get()` not raising on non-2xx responses — deliberate design ("safer as it passes
+  things through," per review). Only flag if the *caller* drops the failure silently (focus area
+  9), not the client's non-raising behavior itself.
+- `print()` used for CLI-facing output — confirmed intentional ("this is the intended output, not
+  really logging"). Don't suggest converting these to `logger` calls.
+- The manifest wrapper not modeling unit-test nodes in certain paths — confirmed as not a real gap
+  where raised ("there's no unit_test/UnitTest reference in the wrapper code" — deliberate scope).
+
+## High-blast-radius — never auto-edit
+
+- `src/vendor/dbt_artifacts_parser/**` — vendored upstream parser; changes must be deliberate forks
+  with a stated reason, not incidental "fixes."
+- `.bumpversion.cfg`, `bump-version.yml`, `tag-release.yml`, `release.sh`, `setup.py` — PyPI release
+  plumbing for `altimate-datapilot-cli`.
+- `pyproject.toml`, `tox.ini`, `.pre-commit-config.yaml` — changing these changes what's enforced
+  repo-wide, not just this PR.
+- `CHANGELOG.rst`, `AUTHORS.rst` — maintained by release tooling, not hand-edited in feature PRs.
+
+## Comment style
+
+- Point at exact lines; one finding per comment; most-severe first.
+- Phrase as suggestions the author can accept or reject, not mandates — link a `diff` snippet if a
+  concrete fix is short.
+- Skip deep review of trivial diffs (README/CHANGELOG-only, formatting-only, dependency bumps with
+  no vendored-parser impact).

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,8 +1,10 @@
 # REVIEW.md — datapilot-cli
 
 Python CLI (`altimate-datapilot-cli` on PyPI) that parses dbt `manifest.json`/`catalog.json`
-artifacts across dbt manifest schema versions (vendored `dbt-artifacts-parser`, v1–v12) and runs
+artifacts (vendored `dbt-artifacts-parser` schema types span manifest v1–v12) and runs
 data-quality "insight" checks over dbt projects, usable standalone or as a pre-commit hook.
+Insight-check processing itself is narrower — `DBTFactory.get_manifest_wrapper` only wraps
+v10/v11/v12, raising `AltimateNotSupportedError` for older versions.
 
 ## Goal: catch what CI cannot
 
@@ -17,7 +19,9 @@ This repo's `pre-commit` + `tox` pipeline (ruff, black) already enforces, so nev
 - Unused imports/variables, bare `except`, raise-from style (`RUF`, `RSE`), bugbear patterns (`B`),
   comprehension style (`C4`), pathlib usage (`PTH`), quote style (`Q`), pytest style (`PT`).
 - Naive `datetime` construction — ruff's `DTZ` rule already catches this.
-- Basic `flake8-bandit` (`S`) security smells (e.g. `assert` in non-test code, `eval`/`exec`).
+- `eval`/`exec` usage (`flake8-bandit` `S102`/`S307`, still enforced). Exception: `S101` (assert)
+  is ignored in `pyproject.toml`, so CI does NOT catch `assert` in non-test code — flag it (it also
+  vanishes under `python -O`).
 - Line length (140 cols, ruff-enforced).
 - Whether tests exist/pass — `tox` runs the suite; that's CI's job, not yours.
 Pre-existing issues in code the diff doesn't touch are out of scope — only review changed lines
@@ -53,9 +57,10 @@ call site actually surfaces failures to the user before claiming error handling 
 2. **Fields marked required on node wrapper models** (#98, #95, #96 — `identifier`,
    `resource_type` made optional after crashing on `Disabled*`/unit-test nodes). A field required
    on the "normal" node case often isn't populated on disabled nodes, unit-test nodes, or older
-   manifest versions. Flag any new required (non-`Optional`) field added to an `Altimate*` node
-   model; verify it's actually present across disabled/unit-test/seed/source variants, not just
-   the common model case.
+   manifest versions. Note: with `pydantic>=2.0`, `Optional[str]` without a default (`= None`) is
+   still required — don't treat `Optional`-typed as automatically safe. Flag any new required field
+   added to an `Altimate*` node model; verify it's actually present across
+   disabled/unit-test/seed/source variants, not just the common model case.
 
 3. **Version-specific field access without a version guard** (e.g. `deferred` not present on v12
    `RPCNode`; behavior tied to a specific dbt/artifact-parser version). Flag direct attribute
@@ -71,39 +76,36 @@ call site actually surfaces failures to the user before claiming error handling 
    `dbt docs generate` output can be stale relative to the manifest. Flag catalog/manifest
    `.nodes[x]` / `.columns[y]` access without a `None`/`KeyError` guard in insight-check code.
 
-6. **Mutable default arguments** (explicitly flagged in review — "list is mutable, weird things can
-   happen" — not reliably caught by this repo's ruff config). Flag `def f(x=[])`, `def f(x={})`, or
-   a list/dict class attribute mutated in place across calls instead of copied per-instance.
+6. **Mutable default arguments** (flagged in review — not reliably caught by this repo's ruff
+   config). Flag `def f(x=[])`, `def f(x={})`, or a list/dict class attribute mutated in place
+   across calls instead of copied per-instance.
 
-7. **Hardcoded materialization/dialect assumptions in insight checks** ("dialects may have
-   multiple materializations and it might flag something we don't want to flag", "use the VIEW
-   constant, we have it somewhere"). Flag magic materialization strings (`"view"`, `"table"`,
-   `"incremental"`) instead of the shared constant, and any check that assumes one dialect's
-   materialization vocabulary applies to all configured warehouses.
+7. **Hardcoded materialization/dialect assumptions in insight checks** (some dialects support
+   multiple materializations for a given config; use the shared `VIEW`-style constant). Flag magic
+   materialization strings (`"view"`, `"table"`, `"incremental"`) instead of the shared constant,
+   and any check that assumes one dialect's materialization vocabulary applies to all configured
+   warehouses.
 
 8. **Duplicated logic across check/insight classes** ("put this in the base `DBTCheck` class so
    it's not repeated", "make it a reusable util"). Flag near-identical blocks copy-pasted across
    files under the insights/checks package instead of factored onto a shared base class or util.
 
-9. **API-client failures not surfaced to the CLI user** ("should handle exceptions and not-200s
-   nicely", "get the response code and log it", "return the status so we inform the user what
-   happened"). The API client intentionally doesn't raise on non-2xx (see Known-intentional) — the
-   bug class is the CLI layer silently swallowing that failure instead of reporting it to the
-   user. Flag call sites that ignore or only debug-log a non-2xx/error API response.
+9. **API-client failures not surfaced to the CLI user**. The API client intentionally doesn't raise
+   on non-2xx (see Known-intentional) — the bug class is the CLI layer silently swallowing that
+   failure instead of reporting it to the user. Flag call sites that ignore or only debug-log a
+   non-2xx/error API response.
 
-10. **Hardcoded environment-specific defaults** ("needs to be injectable from the CLI/environment,
-    not hardcoded"). Flag new hardcoded endpoint/host/instance defaults added to config or client
-    code that aren't also exposed as a CLI flag or env var override.
+10. **Hardcoded environment-specific defaults**. Flag new hardcoded endpoint/host/instance defaults
+    added to config or client code that aren't also exposed as a CLI flag or env var override.
 
-11. **Enum/resource-type completeness across manifest versions** ("how is it mapping between the
-    enums", "not sure all types have labels"). `AltimateResourceType`/`AltimateAccess`-style enums
-    must track new dbt node/resource types introduced by an artifact-parser version bump. Flag a
-    vendored-parser bump or new node type handled without a corresponding Altimate enum member.
+11. **Enum/resource-type completeness across manifest versions**.
+    `AltimateResourceType`/`AltimateAccess`-style enums must track new dbt node/resource types
+    introduced by an artifact-parser version bump. Flag a vendored-parser bump or new node type
+    handled without a corresponding Altimate enum member.
 
 12. **Release/version-bump workflow trigger conditions** (`.bumpversion.cfg`, `bump-version.yml`,
-    `tag-release.yml` — "won't this always release a tag? should be manual"). Flag changes to
-    release-workflow `on:` triggers; verify a routine merge to main can't unintentionally fire a
-    tag/release.
+    `tag-release.yml`). Flag changes to release-workflow `on:` triggers; verify a routine merge to
+    main can't unintentionally fire a tag/release.
 
 ## Repo invariants & landmines
 
@@ -113,11 +115,14 @@ call site actually surfaces failures to the user before claiming error handling 
   vendored dbt-artifacts-parser", "use forked dbt-artifacts-parser") — it exists because upstream
   didn't support something needed here; don't "clean up" divergence from upstream as if it were
   drift.
-- Two distinct run modes with different data completeness: a full CLI run (`datapilot dbt
-  project-health`) vs. the pre-commit hook, which partially generates manifest/catalog from only
-  changed files. Manifest-loading changes need to work under both.
-- Minimum supported Python is 3.7 per README — avoid relying on syntax/stdlib features unavailable
-  there unless the actual tox/CI matrix has been checked.
+- Two run modes, both load the *full* manifest/catalog from disk (`load_manifest_file`/
+  `load_catalog_file`, default `target/manifest.json`/`target/catalog.json`): a full CLI run
+  (`datapilot dbt project-health`) vs. the pre-commit hook. The hook's `process_changed_files` only
+  narrows which models get insight-checked — it does not generate a partial manifest/catalog.
+  Manifest-loading changes need to work under both.
+- Minimum supported Python is 3.8 (`setup.py` `python_requires=">=3.8"`, `pyproject.toml`/`tox.ini`
+  `target-version = "py38"`) — README's "3.7 or higher" is stale; avoid syntax/stdlib features
+  unavailable in 3.8 unless the tox/CI matrix has been checked.
 - `--catalog-path` is optional; code paths must degrade gracefully (skip catalog-dependent
   insights) rather than assume catalog data is present.
 


### PR DESCRIPTION
## What this is

`REVIEW.md` is repo-specific guidance for the KiloCode automated code reviewer. Kilo reads it from
the PR base branch, so it activates once this merges to `main` (enable **Use REVIEW.md** in Kilo's
repo settings).

## How it was built

Mined this repo's history in one bounded pass: 113 commits, 11 fix commits over the last 18
months, and ~90 human PR review comments. The focus areas are grounded in that evidence, not
generic advice.

## Top focus areas

- **`extra="forbid"` on manifest/catalog wrapper models** — new dbt manifest versions add fields
  the wrapper doesn't know about yet; forbidding extras crashes parsing on a routine dbt bump.
- **Required fields on node models that aren't always populated** — disabled nodes, unit-test
  nodes, and older manifest versions routinely miss fields the "normal" node case has.
- **Version-specific field access without a guard** — fields like `deferred` don't exist on every
  manifest version's node types (e.g. v12 `RPCNode`).
- **Checksum/hash shape assumptions** — `checksum` is a dict on some node types, a string/object on
  others.
- **Catalog/manifest lookups assumed non-`None`** — `--catalog-path` is optional and can be stale
  relative to the manifest.
- **Mutable default arguments** and **duplicated logic across check/insight classes** — both
  called out explicitly in past human review.

Also documents known-intentional patterns (e.g. the API client deliberately not raising on non-2xx,
`print()` used for CLI output) so the reviewer doesn't re-litigate settled decisions, and marks the
vendored `dbt_artifacts_parser` copy and release/version-bump plumbing as high-blast-radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, release, or dependency impact.
> 
> **Overview**
> Adds **REVIEW.md**, repo-specific instructions for the KiloCode automated reviewer once merged to `main` (with **Use REVIEW.md** enabled in repo settings).
> 
> The doc steers reviews toward manifest/catalog correctness and CLI behavior that CI cannot catch—especially Pydantic `extra="forbid"` on wrappers, required fields on disabled/unit-test nodes, version-specific field access, checksum shape assumptions, optional catalog paths, and related bug classes mined from past fixes and review comments. It also lists what **not** to flag (ruff/black/tox coverage, intentional API `print()` behavior, non-raising API client), repo invariants (vendored parser, v10–v12 wrapper scope, Python 3.8), and high-blast-radius paths the bot should not auto-edit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecec66e89cc01841e8a5b88c99b365bb6cca4cec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->