### PR TITLE
ci: add aireceipts pr-check (notice-only cost receipt)

### DIFF
--- a/.github/workflows/aireceipts.yml
+++ b/.github/workflows/aireceipts.yml
@@ -1,0 +1,12 @@
+name: aireceipts
+on: [pull_request]
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: npx -y aireceipts-cli@latest pr-check
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/aireceipts.yml
+++ b/.github/workflows/aireceipts.yml
@@ -7,6 +7,6 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - run: npx -y aireceipts-cli@0.5.0 pr-check
+      - run: npx -y aireceipts-cli@latest pr-check
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/aireceipts.yml
+++ b/.github/workflows/aireceipts.yml
@@ -3,10 +3,14 @@ on: [pull_request]
 permissions:
   contents: read
   pull-requests: write
+concurrency:
+  group: aireceipts-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
       - run: npx -y aireceipts-cli@latest pr-check
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/aireceipts.yml
+++ b/.github/workflows/aireceipts.yml
@@ -7,6 +7,6 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - run: npx -y aireceipts-cli@latest pr-check
+      - run: npx -y aireceipts-cli@0.5.0 pr-check
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Adds a **notice-only** aireceipts cost-receipt check (pr-check) — one self-contained workflow, no external reusable workflow, no org Actions-policy change. Never fails a build; posts an aireceipts cost receipt only once a branch carries an aireceipts receipt ref, otherwise a quiet no-op. Coexists with any existing check; remove anytime by deleting the file. Part of an org-wide aireceipts dogfood.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single new CI workflow with read contents and PR write only; failures are ignored and there is no application or auth logic change.
> 
> **Overview**
> Adds a new GitHub Actions workflow **`.github/workflows/aireceipts.yml`** that runs on every pull request and invokes **`aireceipts-cli pr-check`** via `npx` to post an optional AI cost receipt on the PR.
> 
> The job is **notice-only**: **`continue-on-error: true`** so the check never fails the build. It uses **`pull-requests: write`** and **`GH_TOKEN`** for PR comments, with concurrency keyed by ref so overlapping runs cancel. No checkout step—behavior depends on the CLI and branch receipt refs as described in the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b427963efb8d5f524b9591cb711f56f1877ce14c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->