### PR TITLE
chore: [AI-7675] fix test formatting blocking the 0.3.4 release

### DIFF
--- a/tests/test_vendor/test_run_results_pre_v6.py
+++ b/tests/test_vendor/test_run_results_pre_v6.py
@@ -15,9 +15,7 @@ VERSIONS = [1, 2, 3, 4, 5]
 
 
 def _module(version: int):
-    return importlib.import_module(
-        f"vendor.dbt_artifacts_parser.parsers.run_results.run_results_v{version}"
-    )
+    return importlib.import_module(f"vendor.dbt_artifacts_parser.parsers.run_results.run_results_v{version}")
 
 
 def _result(status: str, unique_id: str) -> dict:
@@ -57,10 +55,7 @@ class TestRunResultStatusPreV6:
     def test_known_statuses_preserve_value(self, version):
         mod = _module(version)
         for status in ("success", "error", "skipped"):
-            assert (
-                mod.RunResultOutput(**_result(status, "model.proj.a")).status.value
-                == status
-            )
+            assert mod.RunResultOutput(**_result(status, "model.proj.a")).status.value == status
 
     def test_unknown_future_status_parses(self, version):
         mod = _module(version)
@@ -71,10 +66,7 @@ class TestRunResultStatusPreV6:
         """Test/freshness statuses must keep their `.value` (resolved via Status1/Status2)."""
         mod = _module(version)
         for status in ("pass", "fail", "warn", "runtime error"):
-            assert (
-                mod.RunResultOutput(**_result(status, "test.proj.t")).status.value
-                == status
-            )
+            assert mod.RunResultOutput(**_result(status, "test.proj.t")).status.value == status
 
 
 @pytest.mark.parametrize("version", VERSIONS)
@@ -82,9 +74,7 @@ class TestParseRunResultsEntryPointPreV6:
     """The public `parse_run_results` must parse a full file containing `reused`."""
 
     def test_file_with_reused_result_parses_fully(self, version):
-        run_results = parse_run_results(
-            _run_results(version, "success", "reused", "skipped", "pass", "error", "no-op")
-        )
+        run_results = parse_run_results(_run_results(version, "success", "reused", "skipped", "pass", "error", "no-op"))
         # Previously this whole file was dropped because of the single `reused` row.
         assert len(run_results.results) == 6
         assert {r.status.value for r in run_results.results} == {


### PR DESCRIPTION
## Summary

The `tag-release` run for 0.3.4 ([#122](https://github.com/AltimateAI/datapilot-cli/actions/runs/29949376955)) failed at **Publish to PyPI**: the new test file from #108 wasn't formatted to the repo's `black` line-length 140, and `release.sh` → `tox` → `pre-commit run --all-files` gates the publish. The tag was created but **0.3.4 never reached PyPI** (latest there is 0.3.3).

## Changes

- `black`-formats `tests/test_vendor/test_run_results_pre_v6.py` (formatting only; 36 tests still pass, full `pre-commit run --all-files` green locally).

## Release mechanics

- The stale, unpublished `v0.3.4` tag has been **deleted** so the workflow can recreate it.
- This PR carries the `version-bump` label — merging it re-triggers `tag-release`, which re-tags `v0.3.4` at this merge commit and publishes to PyPI. No version change needed (`.bumpversion.cfg` is already 0.3.4 on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)