### PR TITLE
fix: [AI-8671] accept dbt Fusion's capitalized freshness statuses in sources v1-v3

### DIFF
--- a/src/vendor/dbt_artifacts_parser/parsers/sources/sources_v1.py
+++ b/src/vendor/dbt_artifacts_parser/parsers/sources/sources_v1.py
@@ -38,11 +38,32 @@ class SourceFreshnessRuntimeError(BaseParserModel):
     status: Status
 
 
-class Status1(Enum):
+class Status1(str, Enum):
     pass_ = "pass"
     warn = "warn"
     error = "error"
     runtime_error = "runtime error"
+
+    @classmethod
+    def _missing_(cls, value):
+        # The dbt Fusion engine serializes freshness statuses with its Rust
+        # variant names -- "Pass" / "Warn" / "Error" -- while the published
+        # sources schema it stamps into the artifact, and every dbt-core
+        # release, use the lowercase forms. Fold case first so a Fusion
+        # artifact resolves to the canonical lowercase member and `.value`
+        # stays stable for downstream storage.
+        if isinstance(value, str):
+            folded = value.casefold()
+            for member in cls:
+                if member.value.casefold() == folded:
+                    return member
+        # Forward-compatibility: surface any other unknown status as a real
+        # member so downstream `.value` access keeps working instead of failing
+        # validation and silently dropping the entire sources.json.
+        member = str.__new__(cls, value)
+        member._name_ = str(value)
+        member._value_ = value
+        return member
 
 
 class Period(Enum):

--- a/src/vendor/dbt_artifacts_parser/parsers/sources/sources_v2.py
+++ b/src/vendor/dbt_artifacts_parser/parsers/sources/sources_v2.py
@@ -38,11 +38,32 @@ class SourceFreshnessRuntimeError(BaseParserModel):
     status: Status
 
 
-class Status1(Enum):
+class Status1(str, Enum):
     pass_ = "pass"
     warn = "warn"
     error = "error"
     runtime_error = "runtime error"
+
+    @classmethod
+    def _missing_(cls, value):
+        # The dbt Fusion engine serializes freshness statuses with its Rust
+        # variant names -- "Pass" / "Warn" / "Error" -- while the published
+        # sources schema it stamps into the artifact, and every dbt-core
+        # release, use the lowercase forms. Fold case first so a Fusion
+        # artifact resolves to the canonical lowercase member and `.value`
+        # stays stable for downstream storage.
+        if isinstance(value, str):
+            folded = value.casefold()
+            for member in cls:
+                if member.value.casefold() == folded:
+                    return member
+        # Forward-compatibility: surface any other unknown status as a real
+        # member so downstream `.value` access keeps working instead of failing
+        # validation and silently dropping the entire sources.json.
+        member = str.__new__(cls, value)
+        member._name_ = str(value)
+        member._value_ = value
+        return member
 
 
 class Period(Enum):

--- a/src/vendor/dbt_artifacts_parser/parsers/sources/sources_v3.py
+++ b/src/vendor/dbt_artifacts_parser/parsers/sources/sources_v3.py
@@ -38,11 +38,32 @@ class Results(BaseParserModel):
     status: Status
 
 
-class Status1(Enum):
+class Status1(str, Enum):
     pass_ = "pass"
     warn = "warn"
     error = "error"
     runtime_error = "runtime error"
+
+    @classmethod
+    def _missing_(cls, value):
+        # The dbt Fusion engine serializes freshness statuses with its Rust
+        # variant names -- "Pass" / "Warn" / "Error" -- while the published
+        # sources schema it stamps into the artifact, and every dbt-core
+        # release, use the lowercase forms. Fold case first so a Fusion
+        # artifact resolves to the canonical lowercase member and `.value`
+        # stays stable for downstream storage.
+        if isinstance(value, str):
+            folded = value.casefold()
+            for member in cls:
+                if member.value.casefold() == folded:
+                    return member
+        # Forward-compatibility: surface any other unknown status as a real
+        # member so downstream `.value` access keeps working instead of failing
+        # validation and silently dropping the entire sources.json.
+        member = str.__new__(cls, value)
+        member._name_ = str(value)
+        member._value_ = value
+        return member
 
 
 class Period(Enum):

--- a/tests/test_vendor/test_sources_freshness_status.py
+++ b/tests/test_vendor/test_sources_freshness_status.py
@@ -1,0 +1,127 @@
+"""Tests for the sources v1-v3 parsers, specifically the resilient freshness `Status1` enum.
+
+Regression coverage for the dbt Fusion engine emitting capitalized freshness
+statuses (``"Pass"`` / ``"Warn"`` / ``"Error"``) in sources.json. Every result row
+failed both members of the ``results`` union, so the ENTIRE sources.json raised a
+``ValidationError`` and was silently dropped during ingestion -- no source freshness
+ever reached Postgres for a Fusion-backed environment.
+
+The statuses must fold to their canonical lowercase members, because the extractor
+persists ``result.status.value`` and the rest of the platform (including every
+dbt-core-backed tenant already in the same table) uses the lowercase vocabulary.
+"""
+import pytest
+
+from vendor.dbt_artifacts_parser.parser import parse_sources
+from vendor.dbt_artifacts_parser.parsers.sources.sources_v1 import SourceFreshnessOutput as OutputV1
+from vendor.dbt_artifacts_parser.parsers.sources.sources_v1 import Status1 as StatusV1
+from vendor.dbt_artifacts_parser.parsers.sources.sources_v2 import SourceFreshnessOutput as OutputV2
+from vendor.dbt_artifacts_parser.parsers.sources.sources_v2 import Status1 as StatusV2
+from vendor.dbt_artifacts_parser.parsers.sources.sources_v3 import Results as RuntimeErrorV3
+from vendor.dbt_artifacts_parser.parsers.sources.sources_v3 import Results1 as OutputV3
+from vendor.dbt_artifacts_parser.parsers.sources.sources_v3 import Status1 as StatusV3
+
+V3_SCHEMA = "https://schemas.getdbt.com/dbt/sources/v3.json"
+
+# (output model, status enum) per schema version -- the enum is identical in all three.
+VERSIONS = [
+    pytest.param(OutputV1, StatusV1, id="v1"),
+    pytest.param(OutputV2, StatusV2, id="v2"),
+    pytest.param(OutputV3, StatusV3, id="v3"),
+]
+
+# Fusion's Rust variant name -> the canonical lowercase status dbt-core emits.
+FUSION_CASINGS = [("Pass", "pass"), ("Warn", "warn"), ("Error", "error")]
+
+
+def _output(status: str, unique_id: str = "source.proj.schema.tbl") -> dict:
+    """A complete freshness result -- the shape Fusion always emits."""
+    return {
+        "unique_id": unique_id,
+        "max_loaded_at": "2026-08-19T08:33:50.855920Z",
+        "snapshotted_at": "2026-08-19T17:00:33.833000Z",
+        "max_loaded_at_time_ago_in_s": 30402.0,
+        "status": status,
+        "criteria": {
+            "warn_after": {"count": 24, "period": "hour"},
+            "error_after": {"count": 48, "period": "hour"},
+        },
+        "adapter_response": {},
+        "timing": [],
+        "thread_id": "Thread-20",
+        "execution_time": 0.0,
+    }
+
+
+def _sources_v3(*statuses: str) -> dict:
+    return {
+        "metadata": {
+            "dbt_schema_version": V3_SCHEMA,
+            "dbt_version": "2.0.0-preview.210",
+            "invocation_id": "test-invocation-123",
+        },
+        "elapsed_time": 1.5,
+        "results": [_output(s, f"source.proj.sch.t{i}") for i, s in enumerate(statuses)],
+    }
+
+
+class TestFusionStatusCasing:
+    """Fusion's capitalized statuses must parse AND normalize to lowercase."""
+
+    @pytest.mark.parametrize(("model", "status_enum"), VERSIONS)
+    @pytest.mark.parametrize(("fusion", "canonical"), FUSION_CASINGS)
+    def test_capitalized_status_folds_to_canonical_member(self, model, status_enum, fusion, canonical):
+        result = model(**_output(fusion))
+        assert result.status is status_enum(canonical)
+        assert result.status.value == canonical
+
+    @pytest.mark.parametrize(("model", "status_enum"), VERSIONS)
+    def test_lowercase_statuses_unchanged(self, model, status_enum):
+        """dbt-core's existing lowercase vocabulary must keep resolving as before."""
+        for status in ("pass", "warn", "error", "runtime error"):
+            assert model(**_output(status)).status.value == status
+
+    @pytest.mark.parametrize(("model", "status_enum"), VERSIONS)
+    def test_unknown_future_status_parses(self, model, status_enum):
+        """Forward-compat: a status dbt has not shipped yet must not drop the file."""
+        assert model(**_output("some_future_status")).status.value == "some_future_status"
+
+
+class TestUnionResolutionIsNotLossy:
+    """A complete freshness row must NEVER resolve to the runtime-error branch.
+
+    ``SourcesV3.results`` is ``list[Union[Results, Results1]]`` and ``Results`` (the
+    runtime-error shape) requires only ``unique_id`` + ``status`` with ``extra="allow"``.
+    If a full row resolved there, every freshness field would be dropped -- turning a
+    loud parse failure into silent data loss, which is strictly worse.
+    """
+
+    @pytest.mark.parametrize(("fusion", "canonical"), FUSION_CASINGS)
+    def test_full_row_resolves_to_output_branch(self, fusion, canonical):
+        parsed = parse_sources(_sources_v3(fusion))
+        (result,) = parsed.results
+        assert isinstance(result, OutputV3)
+        assert result.status.value == canonical
+        assert result.max_loaded_at == "2026-08-19T08:33:50.855920Z"
+        assert result.criteria.error_after.count == 48
+
+    def test_runtime_error_row_still_resolves_to_runtime_error_branch(self):
+        """dbt-core emits a distinct, field-less shape for a failed freshness check."""
+        artifact = _sources_v3()
+        artifact["results"] = [
+            {
+                "unique_id": "source.proj.sch.broken",
+                "error": "Database Error: permission denied",
+                "status": "runtime error",
+            }
+        ]
+        (result,) = parse_sources(artifact).results
+        assert isinstance(result, RuntimeErrorV3)
+        assert result.status.value == "runtime error"
+
+
+class TestFullArtifactParse:
+    def test_fusion_artifact_parses_end_to_end(self):
+        """The whole-file failure this regression is about: mixed Fusion statuses."""
+        parsed = parse_sources(_sources_v3("Pass", "Error", "Warn", "Pass"))
+        assert [r.status.value for r in parsed.results] == ["pass", "error", "warn", "pass"]


### PR DESCRIPTION
**dbt Fusion writes source-freshness `status` in PascalCase (`"Pass"` / `"Warn"` / `"Error"`); our `sources` parsers only accept lowercase, so every row fails both members of the `results` union and the entire `sources.json` is rejected.** The ingestion worker wraps parse+extract in one try/except, so the artifact is dropped with no error surfaced.

Fixes [AI-8671](https://altimateai.atlassian.net/browse/AI-8671). This is the residual of [AI-7675](https://altimateai.atlassian.net/browse/AI-7675) — #106/#108 added the `_missing_` shim to the `run_results` status enums but explicitly scoped out the freshness enums, and never touched the `sources` parsers at all.

## Impact (verified in prod Postgres, 2026-08-20)

9 of harvestgroup's 10 production dbt Cloud environments have **zero rows in `dbt_source_freshness`, ever**:

| environment | freshness rows | last row |
| --- | --- | --- |
| Production_287934 | 62,530 | 2026-08-20 02:16 UTC |
| Production_233549 / 248320 / 303301 / 305312 / 305540 / 305605 / 315966 / 346835 / 374935 | **0** | never |

`Production_287934` is the only one still on dbt-core versionless; everything else moved to Fusion. Earliest still-retained failing artifact is 2026-07-23, so this has been dropping for at least a month. `run_results.json` from the same runs parses fine — Fusion writes *those* statuses lowercase — so only source freshness is affected.

## Root cause is upstream

`dbt-labs/dbt-fusion`, `crates/dbt-schemas/src/schemas/common.rs:355`:

```rust
#[derive(Deserialize, Serialize, Debug, Clone, DbtSchema, PartialEq, Eq)]
#[allow(non_camel_case_types)]
pub enum FreshnessStatus { Pass, Warn, Error }

impl std::fmt::Display for FreshnessStatus {          // :363
    let s = match self { Self::Pass => "pass", Self::Warn => "warn", Self::Error => "error" };
```

Missing `#[serde(rename_all = "snake_case")]` — which the next enum in the same file (`DbtMaterialization`, :392) has. The `Display` impl proves lowercase is the intended wire format. Fusion also stamps `dbt_schema_version: .../sources/v3.json` into the file, and that published schema mandates `"enum": ["pass","warn","error","runtime error"]` — so Fusion violates the schema it declares. Our parser is correct to spec.

Also worth knowing: **Fusion has no runtime-error variant at all.** Three members, and `FreshnessResultsArtifact.results` is `Vec<FreshnessResultsNode>` (a single struct, no alternative shape); dbt-core's `SourceFreshnessRuntimeError` has zero hits repo-wide in Fusion.

## The change

`Status1` becomes a `str, Enum` whose `_missing_` case-folds to the canonical lowercase member first, then falls back to the same forward-compat pseudo-member the `run_results` shim uses.

Three deliberate calls:

1. **Case-fold, don't add PascalCase members.** `extraction_helpers.py:372` persists `result.status.value`, and `dbt_source_freshness.py` documents the vocabulary as `pass / warn / error / runtime_error`. PascalCase members would write `Pass` into `dbt_source_freshness` and break every `status = 'error'` filter against the dbt-core tenants already sharing that table.
2. **Leave the runtime-error-only `Status` enum strict.** Fusion never emits that shape, and loosening it would let a row missing a required field fall silently into the field-less branch instead of erroring — turning a loud failure into silent data loss. A test pins that a complete row resolves to the output branch with `max_loaded_at` and `criteria` intact.
3. **Apply to v1–v3, not just v3.** Fusion only emits v3 today, but #108 had to come back and mirror #106 across the older schemas as "the residual"; this is the same 23-line change.

## Verification

432 real production artifacts across all 9 Fusion environments and 13 Fusion builds (`preview.190` → `.210`), each run through parse **and** the worker's own `extract_sources`:

```
RESULT: 432 parsed+extracted OK, 0 FAILED
raw statuses in artifacts : {'Pass': 8039, 'Error': 2540, 'Warn': 314}
extracted .status values  : {'pass': 8039, 'error': 2540, 'warn': 314}   (10,893 rows)
```

`tests/test_vendor/`: 56 passed (20 new). Full suite: 148 passed / 9 failed — those 9 are byte-identical to the `origin/main` baseline I ran in a separate worktree (unrelated `CheckSourceHasMetaKeys` / `SqlCheck` insight tests). `black` clean, `ruff` exit 0 on the new test file (`src/vendor` is excluded from pre-commit by design).

## Shipping

This does not reach prod on merge alone — `altimate-backend/poetry.lock` pins `altimate-datapilot-cli 0.3.4`. Order: **merge this** → merge the `version-bump` PR (fires `tag-release.yml` → tag + PyPI publish) → bump the backend lock. Merging the version bump before this one would cut a release without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[AI-8671]: https://altimateai.atlassian.net/browse/AI-8671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AI-7675]: https://altimateai.atlassian.net/browse/AI-7675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ